### PR TITLE
update actions in CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,9 @@ jobs:
   improve:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: stable
     - name: install linux deps and wasm targets
       run: |
@@ -43,10 +42,9 @@ jobs:
           - os: "windows-latest"
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
       

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - id: create_release
         uses: softprops/action-gh-release@v1
         with:
@@ -33,7 +33,7 @@ jobs:
           - os: macos-latest
 
     steps:
-      - uses: actions/checkout@v1 
+      - uses: actions/checkout@v3
       
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This performs the following updates:
* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* replace unmaintained `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/danbugs/slightjs/actions/runs/4769739371:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.